### PR TITLE
Update pkgbuild and .desktop files

### DIFF
--- a/Tess.desktop
+++ b/Tess.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Exec=/usr/bin/tess
-Icon=/usr/bin/Tess.png
+Icon=tess
 Name=Tess - Terminal
 GenericName=Terminal
 Terminal=False

--- a/appintess.desktop
+++ b/appintess.desktop
@@ -7,4 +7,4 @@ X-KDE-AuthorizeAction=shell_access
 [Desktop Action appintess]
 Name=Execute App in Tess
 Exec=tess --e %f
-Icon=/usr/bin/Tess.png
+Icon=tess

--- a/tess-git/PKGBUILD
+++ b/tess-git/PKGBUILD
@@ -1,17 +1,18 @@
-# Contributor Squitch
-# Contributor FabioLolix
+# Maintainer: FabioLolix
+# Maintainer: squitch
 
 pkgname=tess-git
-pkgver=0.4.2r299.5f30747
+pkgver=0.4.3.r5.gb1592e0
 pkgrel=1
-pkgdesc="Tess hackable, simple, rapid and beautiful terminal for the new era"
+epoch=1
+pkgdesc="Hackable, simple, rapid and beautiful terminal for the new era"
 arch=(x86_64)
-url="https://github.com/SquitchYT/Tess.git"
-license=('unknown')
-depends=("glib2" "glibc" "gtk3")
-makedepends=("git" "npm" "cmake")
-source=("git+$url")
-md5sums=("SKIP")
+url="https://github.com/SquitchYT/Tess"
+license=(MPL2)
+depends=(gtk3 nss)
+makedepends=(git npm cmake chrpath)
+source=("git+https://github.com/SquitchYT/Tess.git")
+sha256sums=('SKIP')
 
 pkgver() {
   cd "Tess"
@@ -20,36 +21,27 @@ pkgver() {
 
 package() {
 	cd "Tess"
-	
 	install -D Tess.desktop "${pkgdir}/usr/share/applications/Tess.desktop"
 	install -D tesshere.desktop "${pkgdir}/usr/share/kservices5/ServiceMenus/tesshere.desktop"
 	install -D appintess.desktop "${pkgdir}/usr/share/kservices5/ServiceMenus/appintess.desktop"
+    install -D src/img/Tess.png "${pkgdir}/usr/share/pixmaps/tess.png"
 
 	if type "$kbuildsycoca5" > /dev/null; then
 		kbuildsycoca5
 	fi
 
-	mkdir -p "${pkgdir}/opt/tess-cli"
-	mkdir -p "${pkgdir}/usr/bin"
-
-    cp "./src/img/Tess.png" "${pkgdir}/usr/bin/Tess.png"
-
-	cd "cli"
-
-	mkdir build && cd build && cmake -S .. -B . && make
-
-	cp -r -f tess-cli "${pkgdir}/opt/tess-cli/tess-cli" 
-	ln -s "/opt/tess-cli/tess-cli" "${pkgdir}/usr/bin/tess-cli"
-
-	cd ../../
-
-	mkdir -p "${pkgdir}/opt/tess"
+    cd cli
+	mkdir -p build 
+    cmake -S . -B build 
+    make -C build
+    install -Dm755 build/tess-cli -t "${pkgdir}/usr/bin/"
+    chrpath --delete "${pkgdir}/usr/bin/tess-cli"
 
 	npm install
 	npm run build
 
-	cd "dist/linux-unpacked"
-
-	cp -r -f * "${pkgdir}/opt/tess/"
-	ln -s "/opt/tess/tess" "${pkgdir}/usr/bin/tess"
+	mkdir -p "${pkgdir}/usr/lib/tess"
+    cd ../dist/linux-unpacked
+	cp -r -f * "${pkgdir}/usr/lib/tess/"
+	ln -s "/usr/lib/tess/tess" "${pkgdir}/usr/bin/tess"
 }

--- a/tesshere.desktop
+++ b/tesshere.desktop
@@ -7,4 +7,4 @@ X-KDE-AuthorizeAction=shell_access
 [Desktop Action opentesshere]
 Name=Execute Tess Here
 Exec=tess --workdir %f
-Icon=/usr/bin/Tess.png
+Icon=tess


### PR DESCRIPTION
> Just a question, why have you add gtk3 to depends ??

gtk3 is needed by the tess binary (this is an electron program and electron use gtk3)

> 
> $ ldd tess | grep gtk
> 	libgtk-3.so.0 => /usr/lib/libgtk-3.so.0 (0x00007f97695bc000)
***
> @a821 Hello, i have never undo change.... 
https://aur.archlinux.org/packages/tess-git/#comment-824784

Some changes have been reverted
https://aur.archlinux.org/cgit/aur.git/commit/?h=tess-git&id=9cc2d50608bb7ec4c5e5a722676f46ca8b5616d2
***
> All of icon is not display correctly....

/usr/bin/ is not a place for icons, .desktop have been updated
***

chrpath have been added as makedepends
> tess-git E: Insecure RPATH '/home/fabio/Dev/Github/PKGBUILD-AUR_fix/zz_aur-fix-2/t/tess-git/src/Tess/cli/build' in file ('usr/bin/tess-cli')
***
There is a problem with cpr library, maye you need to embed it

> $ LANG=C tess-cli
tess-cli: error while loading shared libraries: libcpr.so.1: cannot open shared object file: No such file or directory
***
> license=('unknown')
depends=("glib2" "glibc" "gtk3")
makedepends=("git" "npm" "cmake")

quoting or double quoting in arch=(), license=(), depends=(), etc.. is pointless
The license of your program is MPL2 (Arch packaging typing, see licenses package)
***
Don't use package name in pkgdesc=
***
  epoch=1 is necessary because 0.4.2.rxxx is a downgrade respect to 1.2r234.c480fcf
***
tess-cli can simbly be installed in /usr/bin

for program location use /usr/lib/tess as seen in Firefox, telegram, etc.. packages
