### PR TITLE
:sparkles: Handle quotes when parsing the profile command

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -67,6 +67,8 @@ windows = { version = "^0.60.0", features = [
     "Win32_System_Console",
     "Win32_System_Diagnostics_Debug",
     "Win32_System_Kernel",
+    "Win32_System_Environment",
+    "Win32_UI_Shell",
     "Wdk_System_Threading",
 ] }
 windows-native = "1.0.40"

--- a/src-tauri/src/pty/pty.rs
+++ b/src-tauri/src/pty/pty.rs
@@ -104,14 +104,11 @@ impl Pty {
             built_command
         };
         #[cfg(not(target_os = "windows"))]
-        let mut built_command = {
-            CommandBuilder::from_argv(
-                command
-                    .split(' ')
-                    .map(std::ffi::OsString::from)
-                    .collect::<Vec<OsString>>(),
-            )
-        };
+        let mut built_command = CommandBuilder::from_argv(vec![
+            OsString::from("sh"),
+            OsString::from("-c"),
+            OsString::from(command),
+        ]);
 
         built_command.env("COLORTERM", "truecolor");
         built_command.env("TERM_PROGRAM", "Tess");

--- a/src-tauri/src/pty/pty.rs
+++ b/src-tauri/src/pty/pty.rs
@@ -7,16 +7,20 @@ use crate::common::errors::PtyError;
 use futures::future::join_all;
 use portable_pty::{native_pty_system, Child, CommandBuilder, MasterPty, PtySize};
 use regex_lite::Regex;
-use std::ffi::{OsStr, OsString};
+use std::ffi::{c_void, OsStr, OsString};
 use std::io::{Read, Write};
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Mutex;
+use windows::core::PCWSTR;
+use windows::Win32::Foundation::LocalFree;
+use windows::Win32::System::Environment::ExpandEnvironmentStringsW;
+use windows::Win32::UI::Shell::CommandLineToArgvW;
 
 #[cfg(target_os = "windows")]
-use regex_lite::Captures;
+use std::os::windows::ffi::OsStringExt;
 
 pub struct Pty {
     writer: Mutex<Box<dyn Write + Send>>,
@@ -46,30 +50,59 @@ impl Pty {
         on_notify: impl Fn() + Send + 'static,
         once_exit: impl FnOnce() + Send + 'static,
     ) -> Result<Self, PtyError> {
-        #[cfg(target_os = "windows")]
-        lazy_static::lazy_static! {
-            static ref PROGRAMM_PARSING_REGEX: Regex = Regex::new("%([[:word:]]*)%").unwrap();
-        }
+        let mut built_command = if cfg!(target_os = "windows") {
+            let encoded_command = command
+                .encode_utf16()
+                .chain(std::iter::once(0))
+                .collect::<Vec<u16>>();
 
-        #[cfg(target_os = "windows")]
-        let mut built_command = CommandBuilder::from_argv(
-            PROGRAMM_PARSING_REGEX
-                .replace_all(command, |env_variable: &Captures| {
-                    std::env::var(&env_variable[1]).unwrap_or_default()
-                })
-                .split(' ')
-                .map(std::ffi::OsString::from)
-                .collect::<Vec<OsString>>(),
-        );
+            let expanded_len = unsafe {
+                ExpandEnvironmentStringsW(PCWSTR::from_raw(encoded_command.as_ptr()), None)
+            } as usize;
+            if expanded_len == 0 {
+                return Err(PtyError::Creation("Cannot expand environment".to_owned()));
+            }
 
-        #[cfg(target_family = "unix")]
-        #[allow(unused_mut)]
-        let mut built_command = CommandBuilder::from_argv(
-            command
-                .split(' ')
-                .map(std::ffi::OsString::from)
-                .collect::<Vec<OsString>>(),
-        );
+            let mut command_expanded = vec![0; expanded_len];
+            if unsafe {
+                ExpandEnvironmentStringsW(
+                    PCWSTR::from_raw(encoded_command.as_ptr()),
+                    Some(command_expanded.as_mut_slice()),
+                )
+            } == 0
+            {
+                return Err(PtyError::Creation("Cannot expand environment".to_owned()));
+            }
+
+            let mut argc = 0;
+            let argv = unsafe {
+                CommandLineToArgvW(PCWSTR::from_raw(command_expanded.as_ptr()), &mut argc)
+            };
+            if argv == std::ptr::null_mut() {
+                return Err(PtyError::Creation("Cannot parse command".to_owned()));
+            }
+
+            let built_command = CommandBuilder::from_argv(
+                unsafe { core::slice::from_raw_parts(argv, argc as usize) }
+                    .iter()
+                    .map(|s| OsString::from_wide(unsafe { s.as_wide() }))
+                    .collect(),
+            );
+            unsafe {
+                LocalFree(Some(windows::Win32::Foundation::HLOCAL(
+                    argv as *mut c_void,
+                )))
+            };
+
+            built_command
+        } else {
+            CommandBuilder::from_argv(
+                command
+                    .split(' ')
+                    .map(std::ffi::OsString::from)
+                    .collect::<Vec<OsString>>(),
+            )
+        };
 
         built_command.env("COLORTERM", "truecolor");
         built_command.env("TERM_PROGRAM", "Tess");

--- a/src-tauri/src/pty/pty.rs
+++ b/src-tauri/src/pty/pty.rs
@@ -7,20 +7,26 @@ use crate::common::errors::PtyError;
 use futures::future::join_all;
 use portable_pty::{native_pty_system, Child, CommandBuilder, MasterPty, PtySize};
 use regex_lite::Regex;
-use std::ffi::{c_void, OsStr, OsString};
+use std::ffi::{OsStr, OsString};
 use std::io::{Read, Write};
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Mutex;
-use windows::core::PCWSTR;
-use windows::Win32::Foundation::LocalFree;
-use windows::Win32::System::Environment::ExpandEnvironmentStringsW;
-use windows::Win32::UI::Shell::CommandLineToArgvW;
 
 #[cfg(target_os = "windows")]
+use std::ffi::c_void;
+#[cfg(target_os = "windows")]
 use std::os::windows::ffi::OsStringExt;
+#[cfg(target_os = "windows")]
+use windows::core::PCWSTR;
+#[cfg(target_os = "windows")]
+use windows::Win32::Foundation::LocalFree;
+#[cfg(target_os = "windows")]
+use windows::Win32::System::Environment::ExpandEnvironmentStringsW;
+#[cfg(target_os = "windows")]
+use windows::Win32::UI::Shell::CommandLineToArgvW;
 
 pub struct Pty {
     writer: Mutex<Box<dyn Write + Send>>,
@@ -50,7 +56,8 @@ impl Pty {
         on_notify: impl Fn() + Send + 'static,
         once_exit: impl FnOnce() + Send + 'static,
     ) -> Result<Self, PtyError> {
-        let mut built_command = if cfg!(target_os = "windows") {
+        #[cfg(target_os = "windows")]
+        let mut built_command = {
             let encoded_command = command
                 .encode_utf16()
                 .chain(std::iter::once(0))
@@ -95,7 +102,9 @@ impl Pty {
             };
 
             built_command
-        } else {
+        };
+        #[cfg(not(target_os = "windows"))]
+        let mut built_command = {
             CommandBuilder::from_argv(
                 command
                     .split(' ')

--- a/src-tauri/src/settings/deserialized.rs
+++ b/src-tauri/src/settings/deserialized.rs
@@ -739,7 +739,7 @@ fn default_profile(
         background_transparency,
         uuid,
         #[cfg(target_family = "unix")]
-        command: String::from("sh -c $SHELL"),
+        command: String::from("$SHELL"),
         #[cfg(target_os = "windows")]
         command: String::from("%SystemRoot%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"),
         background: None,

--- a/src-tauri/src/utils/window.rs
+++ b/src-tauri/src/utils/window.rs
@@ -46,14 +46,16 @@ pub async fn create(
     .build()?;
 
     #[cfg(target_family = "unix")]
-    webview.with_webview(|gtk_webview| unsafe {
-        if let Some(handler) = gtk_webview
-            .inner()
-            .data::<gtk::GestureZoom>("wk-view-zoom-gesture")
-        {
-            g_signal_handlers_destroy(handler.as_ptr().cast());
-        }
-    }).ok();
+    webview
+        .with_webview(|gtk_webview| unsafe {
+            if let Some(handler) = gtk_webview
+                .inner()
+                .data::<gtk::GestureZoom>("wk-view-zoom-gesture")
+            {
+                g_signal_handlers_destroy(handler.as_ptr().cast());
+            }
+        })
+        .ok();
 
     match settings.read().await.background {
         #[cfg(target_family = "unix")]


### PR DESCRIPTION
:zap: Improve environment variable substitution in the profile command